### PR TITLE
[Option 2]: Add Ability to Edit User's Comment with Options

### DIFF
--- a/lib/terjira/client/issue.rb
+++ b/lib/terjira/client/issue.rb
@@ -47,6 +47,11 @@ module Terjira
           find(issue)
         end
 
+        def edit_comment(issue, comment_id, message)
+          api_put("issue/#{issue.key_value}/comment/#{comment_id}", { body: message }.to_json)
+          find(issue)
+        end
+
         def create(options = {})
           params = extract_to_fields_params(options)
           resp = api_post 'issue', params.to_json

--- a/lib/terjira/issue_cli.rb
+++ b/lib/terjira/issue_cli.rb
@@ -94,6 +94,29 @@ module Terjira
       render_issue_detail(issue)
     end
 
+    desc 'edit_comment [ISSUE_KEY]', "Edit user's comment on the issue."
+    jira_options :comment_id, :editable_comment
+    def edit_comment(issue)
+      opts = suggest_options(
+        resources: { issue: issue },
+        required: [:editable_comment]
+      )
+
+      if opts['editable_comment'].present?
+        selected_comment = opts['editable_comment']['selected_comment']
+        new_content = opts['editable_comment']['new_content']
+
+        issue = client_class.edit_comment(
+          issue,
+          selected_comment.id,
+          new_content
+        )
+        render_issue_detail(issue)
+      else
+        render("You don't have any editable comment.")
+      end
+    end
+
     desc 'attach_file [ISSUE_KEY] [FILE]', 'Attach a file to the issue'
     jira_options :file
     def attach_file(issue, file)

--- a/lib/terjira/option_support/editor.rb
+++ b/lib/terjira/option_support/editor.rb
@@ -2,13 +2,15 @@
 
 module Terjira
   class Editor
-    def self.editor_text
+    def self.editor_text(content = '')
       editor = ENV['EDITOR']
       if editor.nil? || editor.empty?
         raise 'EDITOR environment variable not found. Please set a default editor.'
       end
 
       tmp_file = Tempfile.new('content')
+      tmp_file.write(content)
+      tmp_file.close
       success = system "#{editor} #{tmp_file.path}"
       content = File.read(tmp_file.path) if success
 

--- a/lib/terjira/option_support/option_selector.rb
+++ b/lib/terjira/option_support/option_selector.rb
@@ -150,6 +150,22 @@ module Terjira
       end
     end
 
+    def select_comment
+      fetch(:editable_comment) do
+        unless user_comments.empty?
+          selected_comment = option_select_prompt.select('Choose comment?') do |menu|
+            user_comments.each do |comment|
+              menu.choice comment.id, comment
+            end
+          end
+
+          new_content = Editor.editor_text(selected_comment.body)
+
+          { 'selected_comment' => selected_comment, 'new_content' => new_content }
+        end
+      end
+    end
+
     def write_description
       fetch(:description) do
         if with_editor?
@@ -169,6 +185,17 @@ module Terjira
     end
 
     private
+
+    def user_comments
+      issue = Client::Issue.find(get(:issue))
+
+      unless issue.comments.empty?
+        issue
+          .comments
+          .reverse
+          .select { |c| c.author['name'] == current_username }
+      end || []
+    end
 
     def prompt_multiline(prompt_for)
       result = option_prompt.multiline("#{prompt_for}?")

--- a/lib/terjira/option_supportable.rb
+++ b/lib/terjira/option_supportable.rb
@@ -24,7 +24,8 @@ module Terjira
       priority: :select_priority,
       resolution: :select_resolution,
       epiclink: :write_epiclink_key,
-      comment: :write_comment
+      comment: :write_comment,
+      editable_comment: :select_comment
     }.freeze
 
     # Transforming and clening options

--- a/lib/terjira/presenters/issue_presenter.rb
+++ b/lib/terjira/presenters/issue_presenter.rb
@@ -122,8 +122,13 @@ module Terjira
         <%= pastel.dim('- ' + remain_comments.size.to_s + ' previous comments exist -') %>
       <% end -%>
       <% visiable_comments.each do |comment| -%>
+
+        <% id = comment.id -%>
+        <% author = comment.author['displayName'] -%>
+        <% created_at = formatted_date(comment.created) -%>
+
         <%= comment.body %>
-        - <%= comment.author['displayName'] %> <%= formatted_date(comment.created) %>
+        - (ID: <%= id %>) <%= author %> <%= created_at %>
       <% end -%>
       """
     end


### PR DESCRIPTION
1. Added Comment ID to comments template. This will give users to choose which comment to edit by Comment ID.

2. Added new Issue sub command to edit user's comment below:

```
jira issue edit_comment [ISSUE_KEY]
```

  - Option shows list of user's previous comment ids.
  - Previous comment's content will be loaded into Editor buffer for editing.
  - If user don't have any comments under the issue, it will prompt "You don't have any editable comment" message.

<a href="https://asciinema.org/a/163493" target="_blank"><img src="https://asciinema.org/a/163493.png" /></a>