### PR TITLE
Bug Fix for Creating New Issue

### DIFF
--- a/lib/terjira/option_support/option_selector.rb
+++ b/lib/terjira/option_support/option_selector.rb
@@ -19,9 +19,12 @@ module Terjira
     def select_project
       fetch :project do
         projects = fetch(:projects) { Client::Project.all }
-        option_select_prompt.select('Choose project?', per_page: per_page(projects)) do |menu|
-          projects.each { |project| menu.choice project_choice_title(project), project }
-        end
+        selected_project =
+          option_select_prompt.select('Choose project?', per_page: per_page(projects)) do |menu|
+            projects.each { |project| menu.choice project_choice_title(project), project }
+          end
+
+        Client::Project.find(selected_project.id)
       end
     end
 

--- a/spec/mock_resource.rb
+++ b/spec/mock_resource.rb
@@ -6,6 +6,12 @@ class MockResource
       end
     end
 
+    def project
+      load_response('project').map do |project|
+        Terjira::Client::Project.build(project)
+      end
+    end
+
     def boards
       load_response('boards')['values'].map do |board|
         Terjira::Client::Board.build(board)

--- a/spec/option/option_supportable_spec.rb
+++ b/spec/option/option_supportable_spec.rb
@@ -18,7 +18,7 @@ describe Terjira::OptionSupportable do
 
   let(:prompt) { TTY::TestPrompt.new }
 
-  %w(projects boards sprints statuses users priorities resolutions).each do |resource|
+  %w(projects project boards sprints statuses users priorities resolutions).each do |resource|
     let(resource) { MockResource.send(resource) }
   end
 
@@ -35,6 +35,7 @@ describe Terjira::OptionSupportable do
 
     it 'suggests proejcts' do
       allow(Terjira::Client::Project).to receive(:all).and_return(projects)
+      allow(Terjira::Client::Project).to receive(:find).and_return(project)
 
       subject.options = { 'project' => 'project' }
       subject.suggest_options


### PR DESCRIPTION
This fix the bug where we get `default index 1 out of range (1 - 0)` error when
we tried to create new Issue. This is because the Project object that we get
from list of Projects does not include Issue Types. Project's Issue Types
only available in individual Project API.

Refer to below issues for more troubleshooting details:

https://github.com/keepcosmos/terjira/issues/51

**Before**

<a href="https://asciinema.org/a/163719" target="_blank"><img src="https://asciinema.org/a/163719.png" /></a>

**After**

<a href="https://asciinema.org/a/163706" target="_blank"><img src="https://asciinema.org/a/163706.png" /></a>