### PR TITLE
Add a snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,33 @@
+name: terjira
+base: core18
+version: git
+summary: Terjira is a very interactive and easy to use CLI tool for Jira
+description: |
+  Terjira is an interactive and easy to use command line interface
+  (or Application) for Jira. You do not need to remember the resource key
+  or id. Terjira suggests it with an interactive prompt.
+
+grade: stable
+confinement: strict
+
+parts:
+  terjira:
+    plugin: dump
+    source: .
+    override-build: |
+      gem build terjira.gemspec
+      gem install *.gem -i $SNAPCRAFT_PART_INSTALL
+    build-packages:
+      - gcc
+      - libc6-dev
+      - make
+      - ruby-dev
+    stage-packages: [ruby]
+
+apps:
+  terjira:
+    environment:
+      RUBYLIB: $SNAP/usr/lib/ruby/2.5.0:$SNAP/usr/lib/x86_64-linux-gnu/ruby/2.5.0
+      GEM_HOME: $SNAP/gems
+      GEM_PATH: $SNAP
+    command: ruby $SNAP/bin/jira


### PR DESCRIPTION
Hi Jaehyun. I stumbled across terjira while trying to find some modern CLI apps, but I couldn't find it distributed. I work on Snapcraft, so I went ahead and created a snap for it. If you build this locally and publish to the [Snap Store](https://snapcraft.io/store), millions of Linux users can browse their way to it. [Ruby upstream](https://snapcraft.io/ruby), [JetBrains](https://snapcraft.io/search?category=&q=jetbrains), and many others are using it to target Linux.

To build:
`snap install snapcraft` from Ubuntu, or [install Multipass](https://github.com/CanonicalLtd/multipass/releases) on MacOS then `brew install snapcraft`.
Run `snapcraft`

To publish:
[Create an account](https://snapcraft.io/account), then:
```
snapcraft login
snapcraft register terjira
snapcraft push --release=stable *.snap
```