### PR TITLE
Migrate away from deprecated codeclimate-test-reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,14 @@ rvm:
 before_install:
   - gem install i18n --no-document
 
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
 script: bundle exec rspec spec/
 
 after_success:
-  - bundle exec codeclimate-test-reporter
+  after_script:
+  - ./cc-test-reporter format-coverage -t simplecov
+  - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,6 @@ GEM
       tzinfo (~> 1.1)
     atlassian-jwt (0.2.0)
       jwt (~> 2.1.0)
-    codeclimate-test-reporter (1.0.8)
-      simplecov (<= 0.13)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
@@ -102,7 +100,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.17)
-  codeclimate-test-reporter (~> 1.0)
   pry (~> 0.12.0)
   rake (~> 13.0)
   rspec (~> 3.9)

--- a/terjira.gemspec
+++ b/terjira.gemspec
@@ -32,6 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "simplecov", "~> 0"
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0"
   spec.add_development_dependency "pry", "~> 0.12.0"
 end


### PR DESCRIPTION
[codeclimate-test-reporter](https://github.com/codeclimate/ruby-test-reporter) has been deprecated. Moving to use Code Climate [pre-built binary](https://docs.codeclimate.com/docs/configuring-test-coverage#section-locations-of-pre-built-binaries).