### PR TITLE
Fix simplecov report

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,11 @@
-require 'terjira'
+require 'simplecov'
 require_relative 'mock_resource'
 require 'pry'
-require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+ add_filter "spec/"
+end
+
+require 'terjira'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/terjira.gemspec
+++ b/terjira.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["keepcosmos@gmail.com"]
 
   spec.summary       = "Terjira is interactive command line application for Jira"
-  spec.description   = "Terjira is interactive and easy to use command line interface (or Application) for Jira.\nYou do not need to remember reosurce key or id. Terjira suggests with interactive prompt."
+  spec.description   = "Terjira is interactive and easy to use command line interface (or Application) for Jira.\nYou do not need to remember resource key or id. Terjira suggests with interactive prompt."
   spec.homepage      = "https://github.com/keepcosmos/terjira"
   spec.license       = "MIT"
 


### PR DESCRIPTION
Fix simplecov report showing only spec files in test coverage.

Before:
![simplecov_before](https://user-images.githubusercontent.com/46582963/67077650-3feda880-f1c2-11e9-9362-ccffa9c3f6f2.png)

After:
![simplecov_after](https://user-images.githubusercontent.com/46582963/67077649-3feda880-f1c2-11e9-821c-a92d0057f338.png)



