### PR TITLE
Catch exception in case user.name is not defined

### DIFF
--- a/lib/terjira/presenters/common_presenter.rb
+++ b/lib/terjira/presenters/common_presenter.rb
@@ -32,7 +32,11 @@ module Terjira
       if user.nil?
         dim_none
       else
-        "#{user.displayName}(#{user.name})"
+        begin
+          "#{user.displayName} (#{user.name})"
+        rescue
+          "#{user.displayName}"
+        end
       end
     end
 

--- a/lib/terjira/presenters/common_presenter.rb
+++ b/lib/terjira/presenters/common_presenter.rb
@@ -34,8 +34,8 @@ module Terjira
       else
         begin
           "#{user.displayName} (#{user.name})"
-        rescue
-          "#{user.displayName}"
+        rescue NoMethodError
+          user.displayName.to_s
         end
       end
     end


### PR DESCRIPTION
Fixes #89 (``undefined method `name' for #<JIRA::Resource::User:0x00007f917299cab8>``)