### PR TITLE
Update login prompt and README to explicitly mention API Token for Jira Cloud Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ If you have permission problem,
 ## Usage
 ```
 Authentication:
-  jira login                         # Login your Jira using your Jira email & API token
+  jira login                         # Login your Jira using your Jira email & password 
+                                     # for Server or API token for Cloud.
                                      # Refer: https://confluence.atlassian.com/cloud/api-tokens-938839638.html
                                      #   [--ssl-config]  with ssl configuration
                                      #   [--proxy-config] with proxy configuration

--- a/lib/terjira/client/auth_option_builder.rb
+++ b/lib/terjira/client/auth_option_builder.rb
@@ -30,7 +30,7 @@ module Terjira
           key(:site).ask('Site (ex: https://myjira.atlassian.net):', required: true)
           key(:context_path).ask('Jira path in your site (just press enter if you don\'t have):', default: '')
           key(:username).ask('Username:', required: true)
-          key(:password).mask('Password:', required: true)
+          key(:password).mask('Password (Server) / API Token (Cloud):', required: true)
 
           if options['ssl-config']
             key(:use_ssl).yes?('Use SSL?')


### PR DESCRIPTION
This PR is to address comments in #97 & #71 and making it explicitly clear that Jira Cloud instances uses only API Token.

Password for Server instances ought to still work (no testing done on my end).