### PR TITLE
Loosening dependency versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     terjira (0.4.8)
-      activesupport (= 6.0.3.3)
-      jira-ruby (= 2.1.0)
+      activesupport (>= 4)
+      jira-ruby (~> 2.1)
       thor (~> 1.0.1)
       tty-prompt (~> 0.20.0)
       tty-spinner (~> 0.9.3)

--- a/terjira.gemspec
+++ b/terjira.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "thor", "~> 1.0.1"
-  spec.add_dependency "jira-ruby", "2.1.0"
-  spec.add_dependency "activesupport", "6.0.3.3"
+  spec.add_dependency "jira-ruby", "~> 2.1"
+  spec.add_dependency "activesupport", ">= 4"
 
   spec.add_dependency "tty-table", "~> 0.11.0"
   spec.add_dependency "tty-prompt", "~> 0.20.0"


### PR DESCRIPTION
I'm adding this gem to a gem of our own. To make things simpler for new comers I'm adding it to our project `Gemfile`s but the strict versions are incompatible.

This pull request losses up dependency versioning so that it can be added as a development dependency to larger projects.